### PR TITLE
Treat vector components as scalars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Version v0.4.1
 
 ## New features
+- The components for vector quantities accesible by `getproperty` are now scalars as oposed to the underlying unwrapped data.
 - Export `unitname`. This function gives the name of the units for the input.
 # Version v0.4
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -54,3 +54,6 @@ function find_field(::Any, rest)
     # @debug "Recursing in the second argument $(typeof(rest))"
     find_field(rest)
 end
+
+Base.getproperty(f::T, k::Symbol) where T <: AbstractPICDataStructure = getproperty(scalarness(T), f, k)
+Base.propertynames(f::T) where T <: AbstractPICDataStructure = propertynames(scalarness(T), f)

--- a/src/recipes/abstractplotting.jl
+++ b/src/recipes/abstractplotting.jl
@@ -3,8 +3,10 @@ include("typerecipes.jl")
 @recipe(FieldPlot) do scene
     Attributes(
         lengthscale_factor = 1,
+        # linewidth_factor = 1,
         arrowsize_factor = 1;
-        :color => nothing,
+        :linewidth => 1,
+        :color => AbstractPlotting.automatic,
         :colormap => :jet1,
         :colorrange => AbstractPlotting.automatic,
         :levels => 6,
@@ -73,7 +75,12 @@ function AbstractPlotting.plot!(sc::FieldPlot{<:Tuple{ScalarField{3}}})
     end
     @lift @debug "Contour plot for 3D ScalarField with " * string($(sc.levels)) * " levels"
 
-    plt = contour!(sc, f; sc.colorrange, sc.colormap, sc.color, levels=sc.levels)
+    plt = contour!(sc, f;
+        sc.colorrange,
+        sc.colormap,
+        sc.color,
+        sc.levels
+    )
 
     return sc
 end
@@ -86,6 +93,7 @@ function AbstractPlotting.plot!(sc::FieldPlot{<:Tuple{VectorField{N}}}) where N
 
     arrowsize = @lift $(sc.arrowsize_factor)*$arrow_norm
     lengthscale = @lift $(sc.lengthscale_factor)/$maxarrow
+    # linewidth = @lift $(sc.linewidth_factor)*$arrow_norm
     valuerange = @lift extrema($arrow_norm)
     replace_automatic!(sc, :colorrange) do
         valuerange
@@ -96,7 +104,8 @@ function AbstractPlotting.plot!(sc::FieldPlot{<:Tuple{VectorField{N}}}) where N
         arrowsize,
         linecolor=arrow_norm,
         lengthscale,
-        linewidth,
+        sc.linewidth,
+        sc.color,
         sc.colormap,
         sc.colorrange
     )

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -35,3 +35,6 @@ function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbstractSca
     @debug "Output data type: $(typeof(data))"
     parameterless_type(f)(data, grid)
 end
+
+Base.getproperty(::ScalarQuantity, f, key::Symbol) = getfield(f, key)
+Base.propertynames(::ScalarQuantity, f::AbstractPICDataStructure) = fieldnames(typeof(f))

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -107,12 +107,15 @@ function Base.similar(f::VectorVariable, ::Type{S}, dims::Dims) where S
 end
 
 # Acessing the internal data storage by column names
-get_property(f, key) = getproperty(unwrapdata(f), key)
+function get_componenet(f::T, key) where T
+    data = getproperty(unwrapdata(f), key)
+    grid = getdomain(f)
 
-Base.getproperty(f::VectorField, key::Symbol) = get_property(f, key)
-Base.getproperty(f::VectorVariable, key::Symbol) = get_property(f, key)
-Base.propertynames(f::VectorField) = propertynames(unwrapdata(f))
-Base.propertynames(f::VectorVariable) = propertynames(unwrapdata(f))
+    scalar_from(T)(data, grid)
+end
+
+Base.getproperty(::VectorQuantity, f, key::Symbol) = get_componenet(f, key)
+Base.propertynames(::VectorQuantity, f::AbstractPICDataStructure) = propertynames(unwrapdata(f))
 
 vector_from(::Type{<:ScalarField}) = VectorField
 vector_from(::Type{<:ScalarVariable}) = VectorVariable


### PR DESCRIPTION
The components for vectors are now scalar fields / variables instead of the corresponding unwrapped data.